### PR TITLE
search bar, sticky header

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "antd": "^5.15.3",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
-        "undici": "^6.10.1"
+        "undici": "^6.10.1",
+        "use-debounce": "^10.0.0"
       },
       "devDependencies": {
         "@types/react": "^18.2.66",
@@ -5521,9 +5522,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "6.10.1",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-6.10.1.tgz",
-      "integrity": "sha512-kSzmWrOx3XBKTgPm4Tal8Hyl3yf+hzlA00SAf4goxv8LZYafKmS6gJD/7Fe5HH/DMNiFTRXvkwhLo7mUn5fuQQ==",
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-6.13.0.tgz",
+      "integrity": "sha512-Q2rtqmZWrbP8nePMq7mOJIN98M0fYvSgV89vwl/BQRT4mDOeY2GXZngfGpcBBhtky3woM7G24wZV3Q304Bv6cw==",
       "engines": {
         "node": ">=18.0"
       }
@@ -5589,14 +5590,25 @@
       "integrity": "sha512-H/A06tKD7sS1O1X2SshBVeA5FLycRpjqiBeqGKmBwBDBy28EnRjORxTNe269KSSr5un5qyWi1iL61wLxpd+ZOg==",
       "dev": true
     },
+    "node_modules/use-debounce": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/use-debounce/-/use-debounce-10.0.0.tgz",
+      "integrity": "sha512-XRjvlvCB46bah9IBXVnq/ACP2lxqXyZj0D9hj4K5OzNroMDpTEBg8Anuh1/UfRTRs7pLhQ+RiNxxwZu9+MVl1A==",
+      "engines": {
+        "node": ">= 16.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0"
+      }
+    },
     "node_modules/vite": {
-      "version": "5.2.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-5.2.4.tgz",
-      "integrity": "sha512-vjFghvHWidBTinu5TCymJk/lRHlR5ljqB83yugr0HA1xspUPdOZHqbqDLnZ8f9/jINrtFHTCYYyIUi+o+Q5iyg==",
+      "version": "5.2.8",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.2.8.tgz",
+      "integrity": "sha512-OyZR+c1CE8yeHw5V5t59aXsUPPVTHMDjEZz8MgguLL/Q7NblxhZUlTu9xSPqlsUO/y+X7dlU05jdhvyycD55DA==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.20.1",
-        "postcss": "^8.4.36",
+        "postcss": "^8.4.38",
         "rollup": "^4.13.0"
       },
       "bin": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "antd": "^5.15.3",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
-    "undici": "^6.10.1"
+    "undici": "^6.10.1",
+    "use-debounce": "^10.0.0"
   },
   "devDependencies": {
     "@types/react": "^18.2.66",

--- a/src/Table.tsx
+++ b/src/Table.tsx
@@ -1,0 +1,57 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck
+import { Flex, Table, Typography, Tooltip, Tag } from 'antd';
+import { purple, gray } from '@ant-design/colors';
+import dayjs from 'dayjs';
+import relativeTime from 'dayjs/plugin/relativeTime';
+import customParseFormat from 'dayjs/plugin/customParseFormat';
+import { memo } from 'react';
+const { Text } = Typography;
+
+dayjs.extend(relativeTime);
+dayjs.extend(customParseFormat);
+
+const arePropsEqual = (prev, next) => prev.query === next.query && prev.page === next.page
+
+const TableComponent = memo(({columns, data, players, lastUpdate, page, setPage}) =>  {
+  // Time
+  const dt = dayjs.unix(lastUpdate);
+
+  // scroll width
+  const scrollWidth = 87 * Object.keys(players).length + 312 + 72
+
+  const tableTitle = () => (<>
+    <Flex justify="space-between" style={{padding: "0 8px"}}>
+    <Text strong>Last updated <Tooltip title={dt.format('dddd, MMMM D, YYYY h:mm A')}>
+        <Tag bordered={false} color={gray[6]} style={{cursor: "default"}}>{dt.fromNow()}</Tag>
+      </Tooltip></Text>
+      <Text>Please tag <b style={{color: purple[3]}}>@cering</b> in the <a className="external" style={{fontWeight: 'bold'}} href="https://discord.com/channels/227650173256466432/958098084276092948" target="_blank" rel="noopener">ITG Events thread</a> to be added to the sheet or to suggest changes!</Text>
+    </Flex>
+  </>);
+
+  //<Switch checkedChildren="Singles" unCheckedChildren="Doubles" defaultChecked/>
+  return (
+    <Table
+      title={tableTitle}
+      dataSource={data}
+      columns={columns}
+      onChange={() => {}}
+      size="small"
+      align="stretch"
+      pagination={{
+        current: page,
+        onChange: (ind) => setPage(ind),
+        size: "small",
+        showLessItems: true,
+        showSizeChanger: false,
+        pageSize: 50,
+        position: ['bottomRight']
+      }}
+      scroll={{ x: scrollWidth }}
+      style={{alignSelf: "stretch"}}
+      sticky
+    />
+  );
+}, arePropsEqual)
+
+export default TableComponent;


### PR DESCRIPTION
![image](https://github.com/aemx/rivals-plus/assets/14956104/9f08a716-b3cc-4b2b-ad36-91de6a6da796)

- names should stick when you scroll down
- table pagination has a search bar now and it filters song titles
  - table is moved into its own component
  - a bunch of data cleanup stuff has been moved out of the main component (sorry thats why all the line changes look weird)